### PR TITLE
Add production cached rates to get better rate for comparing ETH to token

### DIFF
--- a/KyberNetwork/KyberNetwork/Configurations/Environments/Sources/KNEnvironment.swift
+++ b/KyberNetwork/KyberNetwork/Configurations/Environments/Sources/KNEnvironment.swift
@@ -42,7 +42,7 @@ enum KNEnvironment: Int {
   }()
 
   static var `default`: KNEnvironment {
-    return KNAppTracker.externalEnvironment()
+    return .production//KNAppTracker.externalEnvironment()
   }
 
   var isMainnet: Bool {

--- a/KyberNetwork/KyberNetwork/Configurations/Environments/Sources/KNEnvironment.swift
+++ b/KyberNetwork/KyberNetwork/Configurations/Environments/Sources/KNEnvironment.swift
@@ -42,7 +42,7 @@ enum KNEnvironment: Int {
   }()
 
   static var `default`: KNEnvironment {
-    return .production//KNAppTracker.externalEnvironment()
+    return KNAppTracker.externalEnvironment()
   }
 
   var isMainnet: Bool {

--- a/KyberNetwork/KyberNetwork/Configurations/Environments/Sources/KNEnvironment.swift
+++ b/KyberNetwork/KyberNetwork/Configurations/Environments/Sources/KNEnvironment.swift
@@ -153,4 +153,11 @@ enum KNEnvironment: Int {
   }
 
   var nodeEndpoint: String { return "" }
+
+  var cachedRateURL: String {
+    switch KNEnvironment.default {
+    case .mainnetTest, .production, .staging: return KNSecret.prodCachedRateURL
+    case .ropsten, .rinkeby, .kovan: return KNSecret.devCachedRateURL
+    }
+  }
 }

--- a/KyberNetwork/KyberNetwork/Coordinators/AppCoordinator/KNAppCoordinator+Notification.swift
+++ b/KyberNetwork/KyberNetwork/Coordinators/AppCoordinator/KNAppCoordinator+Notification.swift
@@ -136,6 +136,7 @@ extension KNAppCoordinator {
       totalBalanceInUSD: loadBalanceCoordinator.totalBalanceInUSD,
       totalBalanceInETH: loadBalanceCoordinator.totalBalanceInETH
     )
+    self.exchangeCoordinator?.appCoordinatorUpdateExchangeTokenRates()
   }
 
   @objc func exchangeRateUSDDidUpdateNotification(_ sender: Notification) {

--- a/KyberNetwork/KyberNetwork/Coordinators/InternalCoordinators/RateCoordinator/KNRateCoordinator.swift
+++ b/KyberNetwork/KyberNetwork/Coordinators/InternalCoordinators/RateCoordinator/KNRateCoordinator.swift
@@ -54,8 +54,14 @@ class KNRateCoordinator {
     )
   }
 
-  func getCachedProdRate(from: String, to: String) -> KNRate? {
-    return self.cachedProdTokenRates["\(from)_\(to)"]
+  func getCachedProdRate(from: TokenObject, to: TokenObject) -> BigInt? {
+    if let rate = self.cachedProdTokenRates["\(from.symbol)_\(to.symbol)"] { return rate.rate }
+    if let rateToETH = self.cachedProdTokenRates["\(from.symbol)_ETH"],
+      let rateETHTo = self.cachedProdTokenRates["ETH_\(to.symbol)"] {
+      let swapRate = rateToETH.rate * rateETHTo.rate / BigInt(10).power(18)
+      return swapRate
+    }
+    return self.getRate(from: from, to: to)?.rate
   }
 
   func getCacheRate(from: String, to: String) -> KNRate? {

--- a/KyberNetwork/KyberNetwork/Models/KNRate.swift
+++ b/KyberNetwork/KyberNetwork/Models/KNRate.swift
@@ -39,6 +39,19 @@ class KNRate: NSObject {
     }
   }
 
+  init(cachedDict: JSONDictionary) throws {
+    source = cachedDict["source"] as? String ?? ""
+    dest = cachedDict["dest"] as? String ?? ""
+    let tokenSymbol = source == "ETH" ? dest : source
+    if let rateString = cachedDict["rate"] as? String, let rateDouble = Double(rateString),
+      let token = KNSupportedTokenStorage.shared.supportedTokens.first(where: { $0.symbol == tokenSymbol }) {
+      rate = BigInt(rateDouble) / BigInt(10).power(18 - token.decimals)
+      minRate = rate * BigInt(97) / BigInt(100)
+    } else {
+      throw CastError(actualValue: String.self, expectedType: BigInt.self)
+    }
+  }
+
   init(source: String, dest: String, rate: Double, decimals: Int) {
     self.source = source
     self.dest = dest

--- a/KyberNetwork/KyberNetwork/Models/KNRate.swift
+++ b/KyberNetwork/KyberNetwork/Models/KNRate.swift
@@ -41,11 +41,11 @@ class KNRate: NSObject {
 
   init(cachedDict: JSONDictionary) throws {
     source = cachedDict["source"] as? String ?? ""
-    dest = cachedDict["dest"] as? String ?? ""
-    let tokenSymbol = source == "ETH" ? dest : source
-    if let rateString = cachedDict["rate"] as? String, let rateDouble = Double(rateString),
+    let tokenSymbol = cachedDict["dest"] as? String ?? ""
+    dest = tokenSymbol
+    if let rateString = cachedDict["rate"] as? String, let rateBig = BigInt(rateString),
       let token = KNSupportedTokenStorage.shared.supportedTokens.first(where: { $0.symbol == tokenSymbol }) {
-      rate = BigInt(rateDouble) / BigInt(10).power(18 - token.decimals)
+      rate = rateBig / BigInt(10).power(18 - token.decimals)
       minRate = rate * BigInt(97) / BigInt(100)
     } else {
       throw CastError(actualValue: String.self, expectedType: BigInt.self)

--- a/KyberNetwork/KyberNetwork/Networking/Internal/KNInternalProvider.swift
+++ b/KyberNetwork/KyberNetwork/Networking/Internal/KNInternalProvider.swift
@@ -65,7 +65,7 @@ class KNInternalProvider {
               for json in jsonArr {
                 do {
                   let rate = try KNRate(cachedDict: json)
-                  if rate.source == "ETH" { rates.append(rate) }
+                  rates.append(rate)
                 } catch {}
               }
               completion(.success(rates))

--- a/KyberNetwork/KyberNetwork/Networking/Internal/KNInternalProvider.swift
+++ b/KyberNetwork/KyberNetwork/Networking/Internal/KNInternalProvider.swift
@@ -50,6 +50,36 @@ class KNInternalProvider {
     }
   }
 
+  func getProductionCachedRate(completion: @escaping (Result<[KNRate], AnyError>) -> Void) {
+    DispatchQueue.global(qos: .background).async {
+      self.provider.request(.getCachedRate) { [weak self] (result) in
+        guard let _ = `self` else { return }
+        DispatchQueue.main.async {
+          switch result {
+          case .success(let response):
+            do {
+              _ = try response.filterSuccessfulStatusCodes()
+              let json: JSONDictionary = try response.mapJSON() as? JSONDictionary ?? [:]
+              let jsonArr = json["data"] as? [JSONDictionary] ?? []
+              var rates: [KNRate] = []
+              for json in jsonArr {
+                do {
+                  let rate = try KNRate(cachedDict: json)
+                  if rate.source == "ETH" { rates.append(rate) }
+                } catch {}
+              }
+              completion(.success(rates))
+            } catch let error {
+              completion(.failure(AnyError(error)))
+            }
+          case .failure(let error):
+            completion(.failure(AnyError(error)))
+          }
+        }
+      }
+    }
+  }
+
   func getKNExchangeRateUSD(completion: @escaping (Result<[KNRate], AnyError>) -> Void) {
     DispatchQueue.global(qos: .background).async {
       self.provider.request(.getRateUSD) { [weak self] (result) in

--- a/KyberNetwork/KyberNetwork/Networking/Internal/KyberNetworkService.swift
+++ b/KyberNetwork/KyberNetwork/Networking/Internal/KyberNetworkService.swift
@@ -5,7 +5,7 @@ import CryptoSwift
 
 enum KyberNetworkService: String {
   case getRate = "/token_price?currency=ETH"
-  case getCachedRate = "/getRate"
+  case getCachedRate = "/rate"
   case getRateUSD = "/token_price?currency=USD"
   case getHistoryOneColumn = "/getHistoryOneColumn"
   case getLatestBlock = "/latestBlock"
@@ -19,7 +19,9 @@ extension KyberNetworkService: TargetType {
 
   var baseURL: URL {
     let baseURLString: String = {
-      if case .getCachedRate = self { return KNSecret.prodCachedRateURL }
+      if case .getCachedRate = self {
+        return KNEnvironment.default.cachedRateURL
+      }
       if case .supportedToken = self {
         return KNEnvironment.default.supportedTokenEndpoint
       }

--- a/KyberNetwork/KyberNetwork/Networking/Internal/KyberNetworkService.swift
+++ b/KyberNetwork/KyberNetwork/Networking/Internal/KyberNetworkService.swift
@@ -5,6 +5,7 @@ import CryptoSwift
 
 enum KyberNetworkService: String {
   case getRate = "/token_price?currency=ETH"
+  case getCachedRate = "/getRate"
   case getRateUSD = "/token_price?currency=USD"
   case getHistoryOneColumn = "/getHistoryOneColumn"
   case getLatestBlock = "/latestBlock"
@@ -18,6 +19,7 @@ extension KyberNetworkService: TargetType {
 
   var baseURL: URL {
     let baseURLString: String = {
+      if case .getCachedRate = self { return KNSecret.prodCachedRateURL }
       if case .supportedToken = self {
         return KNEnvironment.default.supportedTokenEndpoint
       }

--- a/KyberNetwork/KyberNetwork/Screens/CommonViews/Confirms/SwapConfirm/ViewModel/KConfirmSwapViewModel.swift
+++ b/KyberNetwork/KyberNetwork/Screens/CommonViews/Confirms/SwapConfirm/ViewModel/KConfirmSwapViewModel.swift
@@ -45,7 +45,7 @@ struct KConfirmSwapViewModel {
   }
 
   var percentageRateDiff: Double {
-    guard let rate = KNRateCoordinator.shared.getRate(from: self.transaction.from, to: self.transaction.to), !rate.rate.isZero else {
+    guard let rate = KNRateCoordinator.shared.getCachedProdRate(from: self.transaction.from.symbol, to: self.transaction.to.symbol), !rate.rate.isZero else {
       return 0.0
     }
     if self.transaction.expectedRate.isZero { return 0.0 }

--- a/KyberNetwork/KyberNetwork/Screens/CommonViews/Confirms/SwapConfirm/ViewModel/KConfirmSwapViewModel.swift
+++ b/KyberNetwork/KyberNetwork/Screens/CommonViews/Confirms/SwapConfirm/ViewModel/KConfirmSwapViewModel.swift
@@ -45,11 +45,11 @@ struct KConfirmSwapViewModel {
   }
 
   var percentageRateDiff: Double {
-    guard let rate = KNRateCoordinator.shared.getCachedProdRate(from: self.transaction.from.symbol, to: self.transaction.to.symbol), !rate.rate.isZero else {
+    guard let rate = KNRateCoordinator.shared.getCachedProdRate(from: self.transaction.from, to: self.transaction.to), !rate.isZero else {
       return 0.0
     }
     if self.transaction.expectedRate.isZero { return 0.0 }
-    let marketRateDouble = Double(rate.rate) / pow(10.0, Double(self.transaction.to.decimals))
+    let marketRateDouble = Double(rate) / pow(10.0, Double(self.transaction.to.decimals))
     let estimatedRateDouble = Double(self.transaction.expectedRate) / pow(10.0, Double(self.transaction.to.decimals))
     let change = (estimatedRateDouble - marketRateDouble) / marketRateDouble * 100.0
     if change >= -0.1 { return 0.0 }

--- a/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/NewDesign/ViewModel/KSwapViewModel.swift
+++ b/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/NewDesign/ViewModel/KSwapViewModel.swift
@@ -49,6 +49,7 @@ class KSwapViewModel {
     self.from = from
     self.to = to
     self.supportedTokens = supportedTokens
+    self.updateProdCachedRate()
   }
 
   var headerBackgroundColor: UIColor { return KNAppStyleType.current.swapFlowHeaderColor }
@@ -125,8 +126,10 @@ class KSwapViewModel {
     return expectedExchange.string(decimals: self.from.decimals, minFractionDigits: 6, maxFractionDigits: 6)
   }
 
+  fileprivate var cachedProdRate: BigInt?
+
   var percentageRateDiff: Double {
-    guard let rate = KNRateCoordinator.shared.getCachedProdRate(from: self.from, to: self.to), !rate.isZero else {
+    guard let rate = self.cachedProdRate ?? KNRateCoordinator.shared.getCachedProdRate(from: self.from, to: self.to), !rate.isZero else {
       return 0.0
     }
     if self.estimatedRateDouble == 0 { return 0.0 }
@@ -337,10 +340,15 @@ class KSwapViewModel {
     self.estRate = nil
     self.slippageRate = nil
     self.estimateGasLimit = KNGasConfiguration.calculateDefaultGasLimit(from: self.from, to: self.to)
+    self.updateProdCachedRate()
   }
 
   func updateWalletObject() {
     self.walletObject = KNWalletStorage.shared.get(forPrimaryKey: self.walletObject.address) ?? self.walletObject
+  }
+
+  func updateProdCachedRate(_ rate: BigInt? = nil) {
+    self.cachedProdRate = rate ?? KNRateCoordinator.shared.getCachedProdRate(from: self.from, to: self.to)
   }
 
   func swapTokens() {
@@ -353,6 +361,7 @@ class KSwapViewModel {
     self.slippageRate = nil
     self.estimateGasLimit = KNGasConfiguration.calculateDefaultGasLimit(from: self.from, to: self.to)
     self.balance = self.balances[self.from.contract]
+    self.updateProdCachedRate()
   }
 
   func updateSelectedToken(_ token: TokenObject, isSource: Bool) {
@@ -372,6 +381,7 @@ class KSwapViewModel {
     self.slippageRate = nil
     self.estimateGasLimit = KNGasConfiguration.calculateDefaultGasLimit(from: self.from, to: self.to)
     self.balance = self.balances[self.from.contract]
+    self.updateProdCachedRate()
   }
 
   func updateEstimatedRateFromCachedIfNeeded() {

--- a/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/NewDesign/ViewModel/KSwapViewModel.swift
+++ b/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/NewDesign/ViewModel/KSwapViewModel.swift
@@ -126,7 +126,7 @@ class KSwapViewModel {
   }
 
   var percentageRateDiff: Double {
-    guard let rate = KNRateCoordinator.shared.getRate(from: self.from, to: self.to), !rate.rate.isZero else {
+    guard let rate = KNRateCoordinator.shared.getCachedProdRate(from: self.from.symbol, to: self.to.symbol), !rate.rate.isZero else {
       return 0.0
     }
     if self.estimatedRateDouble == 0 { return 0.0 }

--- a/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/NewDesign/ViewModel/KSwapViewModel.swift
+++ b/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/NewDesign/ViewModel/KSwapViewModel.swift
@@ -126,11 +126,11 @@ class KSwapViewModel {
   }
 
   var percentageRateDiff: Double {
-    guard let rate = KNRateCoordinator.shared.getCachedProdRate(from: self.from.symbol, to: self.to.symbol), !rate.rate.isZero else {
+    guard let rate = KNRateCoordinator.shared.getCachedProdRate(from: self.from, to: self.to), !rate.isZero else {
       return 0.0
     }
     if self.estimatedRateDouble == 0 { return 0.0 }
-    let marketRateDouble = Double(rate.rate) / pow(10.0, Double(self.to.decimals))
+    let marketRateDouble = Double(rate) / pow(10.0, Double(self.to.decimals))
     let change = (self.estimatedRateDouble - marketRateDouble) / marketRateDouble * 100.0
     if change > -0.1 { return 0.0 }
     return change

--- a/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/SwapVC/Coordinator/KNExchangeTokenCoordinator.swift
+++ b/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/SwapVC/Coordinator/KNExchangeTokenCoordinator.swift
@@ -131,6 +131,10 @@ extension KNExchangeTokenCoordinator {
     self.confirmSwapVC?.coordinatorUpdateCurrentMarketRate()
   }
 
+  func appCoordinatorUpdateExchangeTokenRates() {
+    self.confirmSwapVC?.coordinatorUpdateCurrentMarketRate()
+  }
+
   func appCoordinatorShouldOpenExchangeForToken(_ token: TokenObject, isReceived: Bool = false) {
     self.navigationController.popToRootViewController(animated: true)
     self.rootViewController.coordinatorUpdateSelectedToken(token, isSource: !isReceived)

--- a/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/SwapVC/Coordinator/KNExchangeTokenCoordinator.swift
+++ b/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/SwapVC/Coordinator/KNExchangeTokenCoordinator.swift
@@ -132,6 +132,7 @@ extension KNExchangeTokenCoordinator {
   }
 
   func appCoordinatorUpdateExchangeTokenRates() {
+    self.rootViewController.coordinatorUpdateProdCachedRates()
     self.confirmSwapVC?.coordinatorUpdateCurrentMarketRate()
   }
 
@@ -313,6 +314,8 @@ extension KNExchangeTokenCoordinator: KSwapViewControllerDelegate {
       self.openSearchToken(from: from, to: to, isSource: isSource)
     case .estimateRate(let from, let to, let amount, let showError):
       self.updateEstimatedRate(from: from, to: to, amount: amount, showError: showError)
+    case .estimateComparedRate(let from, let to):
+      self.updateComparedEstimateRate(from: from, to: to)
     case .estimateGas(let from, let to, let amount, let gasPrice):
       self.updateEstimatedGasLimit(from: from, to: to, amount: amount, gasPrice: gasPrice)
     case .getUserCapInWei:
@@ -441,23 +444,74 @@ extension KNExchangeTokenCoordinator: KSwapViewControllerDelegate {
     }
   }
 
+  // Update compared rate from node when prod cached failed to load
+  // This rate is to compare with current rate to show warning
+  fileprivate func updateComparedEstimateRate(from: TokenObject, to: TokenObject) {
+    let amount: BigInt = {
+      if from.isETH { return BigInt(10).power(from.decimals) / BigInt(2) }
+      if let rate = KNRateCoordinator.shared.ethRate(for: from), !rate.rate.isZero {
+        let ethAmount = BigInt(10).power(from.decimals) / BigInt(2)
+        let amount = ethAmount * BigInt(10).power(to.decimals) / rate.rate
+        return amount
+      }
+      return BigInt(10).power(from.decimals / 2)
+    }()
+    self.getExpectedExchangeRate(from: from, to: to, amount: amount) { [weak self] result in
+      if case .success(let data) = result {
+        self?.rootViewController.coordinatorUpdateComparedRateFromNode(
+          from: from,
+          to: to,
+          rate: data.0
+        )
+      }
+    }
+  }
+
+  // Call contract to get estimate rate with src, dest, srcAmount
   fileprivate func updateEstimatedRate(from: TokenObject, to: TokenObject, amount: BigInt, showError: Bool, completion: ((Error?) -> Void)? = nil) {
+    self.getExpectedExchangeRate(from: from, to: to, amount: amount) { [weak self] result in
+      guard let `self` = self else { return }
+      switch result {
+      case .success(let data):
+        self.rootViewController.coordinatorDidUpdateEstimateRate(
+          from: from,
+          to: to,
+          amount: amount,
+          rate: data.0,
+          slippageRate: data.1
+        )
+        completion?(nil)
+      case .failure(let error):
+        if showError {
+          self.navigationController.showErrorTopBannerMessage(
+            with: NSLocalizedString("error", value: "Error", comment: ""),
+            message: NSLocalizedString("can.not.update.exchange.rate", comment: "Can not update exchange rate"),
+            time: 1.5
+          )
+          self.rootViewController.coordinatorDidUpdateEstimateRate(
+            from: from,
+            to: to,
+            amount: amount,
+            rate: BigInt(0),
+            slippageRate: BigInt(0)
+          )
+        }
+        completion?(error)
+      }
+    }
+  }
+
+  fileprivate func getExpectedExchangeRate(from: TokenObject, to: TokenObject, amount: BigInt, completion: ((Result<(BigInt, BigInt), AnyError>) -> Void)? = nil) {
     if from == to {
       let rate = BigInt(10).power(from.decimals)
-      self.rootViewController.coordinatorDidUpdateEstimateRate(
-        from: from,
-        to: to,
-        amount: amount,
-        rate: rate,
-        slippageRate: rate * BigInt(97) / BigInt(100)
-      )
-      completion?(nil)
+      let slippageRate = rate * BigInt(97) / BigInt(100)
+      completion?(.success((rate, slippageRate)))
       return
     }
     self.session.externalProvider.getExpectedRate(
       from: from,
       to: to,
-      amount: amount) { [weak self] (result) in
+      amount: amount) { (result) in
         var estRate: BigInt = BigInt(0)
         var slippageRate: BigInt = BigInt(0)
         switch result {
@@ -466,30 +520,9 @@ extension KNExchangeTokenCoordinator: KSwapViewControllerDelegate {
           slippageRate = data.1
           estRate /= BigInt(10).power(18 - to.decimals)
           slippageRate /= BigInt(10).power(18 - to.decimals)
-          self?.rootViewController.coordinatorDidUpdateEstimateRate(
-            from: from,
-            to: to,
-            amount: amount,
-            rate: estRate,
-            slippageRate: slippageRate
-          )
-          completion?(nil)
+          completion?(.success((estRate, slippageRate)))
         case .failure(let error):
-          if showError {
-            self?.navigationController.showErrorTopBannerMessage(
-              with: NSLocalizedString("error", value: "Error", comment: ""),
-              message: NSLocalizedString("can.not.update.exchange.rate", comment: "Can not update exchange rate"),
-              time: 1.5
-            )
-            self?.rootViewController.coordinatorDidUpdateEstimateRate(
-              from: from,
-              to: to,
-              amount: amount,
-              rate: BigInt(0),
-              slippageRate: BigInt(0)
-            )
-          }
-          completion?(error)
+          completion?(.failure(error))
         }
     }
   }

--- a/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/SwapVC/Coordinator/KNExchangeTokenCoordinator.swift
+++ b/KyberNetwork/KyberNetwork/Screens/Tabbars/KyberSwap/SwapVC/Coordinator/KNExchangeTokenCoordinator.swift
@@ -447,6 +447,7 @@ extension KNExchangeTokenCoordinator: KSwapViewControllerDelegate {
   // Update compared rate from node when prod cached failed to load
   // This rate is to compare with current rate to show warning
   fileprivate func updateComparedEstimateRate(from: TokenObject, to: TokenObject) {
+    // Using default amount equivalent to 0.5 ETH
     let amount: BigInt = {
       if from.isETH { return BigInt(10).power(from.decimals) / BigInt(2) }
       if let rate = KNRateCoordinator.shared.ethRate(for: from), !rate.rate.isZero {
@@ -457,7 +458,7 @@ extension KNExchangeTokenCoordinator: KSwapViewControllerDelegate {
       return BigInt(10).power(from.decimals / 2)
     }()
     self.getExpectedExchangeRate(from: from, to: to, amount: amount) { [weak self] result in
-      if case .success(let data) = result {
+      if case .success(let data) = result, !data.0.isZero {
         self?.rootViewController.coordinatorUpdateComparedRateFromNode(
           from: from,
           to: to,

--- a/KyberNetwork/KyberNetwork/Utilities/KNNotificationUtil.swift
+++ b/KyberNetwork/KyberNetwork/Utilities/KNNotificationUtil.swift
@@ -21,6 +21,7 @@ let kOtherBalanceDidUpdateNotificationKey = "kOtherBalanceDidUpdateNotificationK
 // Rate
 let kExchangeTokenRateNotificationKey = "kExchangeTokenRateNotificationKey"
 let kExchangeUSDRateNotificationKey = "kExchangeUSDRateNotificationKey"
+let kProdCachedRateFailedToLoadNotiKey = "kProdCachedRateFailedToLoadNotiKey"
 
 let kCoinTickersDidUpdateNotificationKey = "kCoinTickerDataDidUpdateNotificationKey"
 


### PR DESCRIPTION
token price API only returns rate token to ETH, using 1/token_to_ETH_rate to show warning with rate ETH/token when doing swap is not a good way
production cached rate returns rate from ETH to token, so it will be more accurate to use this API.